### PR TITLE
Add an option to cusomize the max height of the error list

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Hide error codes in error list (if you don't use error ignoring or error codes c
 let jshint2_error = 0
 ```
 
+Customize the max height of the error list:
+
+```vim
+let jshint2_height = 10
+```
+
 ## Tips
 
 Quick lint mapping:

--- a/plugin/jshint2.vim
+++ b/plugin/jshint2.vim
@@ -54,6 +54,11 @@ if !exists('g:jshint2_error')
 	let g:jshint2_error = 1
 endif
 
+" define the default height of the error list
+if !exists('g:jshint2_height')
+	let g:jshint2_height = 10
+endif
+
 " define completion dictionary
 if !exists('g:jshint2_completion')
 	let g:jshint2_completion = {
@@ -257,7 +262,7 @@ function s:Lint(start, stop, show, ...)
 
 		" open location list if there is no bang
 		if a:show
-			belowright lopen
+			execute 'belowright lopen '.g:jshint2_height
 		endif
 	else
 		call s:Echo('More', 'JSHint did not find any errors.'.l:ignored)


### PR DESCRIPTION
I found this is useful when working with a few buffers in horizontal splits and 10 line is just too big of a space to take.
