### PR TITLE
If the Quickfix buffer is the only one open close it. Before executing a

### DIFF
--- a/plugin/jshint2.vim
+++ b/plugin/jshint2.vim
@@ -343,6 +343,8 @@ augroup jshint2
 	" lint files after saving
 	if g:jshint2_save
 		autocmd BufWritePost * if &filetype == 'javascript' | silent JSHint | endif
+        "If last open buffer is a quickfix close it
+        autocmd BufEnter * if &buftype == 'quickfix' && winnr('$') < 2 | quit! | endif
 	endif
 
 	" map commands for error list


### PR DESCRIPTION
:wq in a file with errors with jshint2_save left vim with only the
Quickfix buffer open and it would eat all input.

resolves issue 7
